### PR TITLE
Fix authorization errors with carts/orders

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -61,10 +61,8 @@ module Spree
         def remove_invalid_session_order_id
           return unless session[:order_id]
 
-          user = try_spree_current_user
           order = Spree::Order.find(session[:order_id]) rescue nil
-
-          session[:order_id] = nil if order.nil? || order.user != user
+          session[:order_id] = nil unless can?(:edit, order, session[:access_token])
         end
 
         def set_current_order

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -58,7 +58,22 @@ module Spree
           session[:guest_token] = nil
         end
 
+        def remove_invalid_session_order_id
+          user = try_spree_current_user
+
+          if session[:order_id]
+            order = Spree::Order.find(session[:order_id])
+            if user && order.user != user
+              session[:order_id] = nil
+            elsif !user && && order.user_id
+              session[:order_id] = nil
+            end
+          end
+        end
+
         def set_current_order
+          remove_invalid_session_order_id
+
           if user = try_spree_current_user
             last_incomplete_order = user.last_incomplete_spree_order
             if session[:order_id].nil? && last_incomplete_order

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -15,6 +15,9 @@ module Spree
           options[:create_order_if_necessary] ||= false
           options[:lock] ||= false
           return @current_order if @current_order
+
+          remove_invalid_session_order_id
+
           if session[:order_id]
             current_order = Spree::Order.includes(:adjustments).lock(options[:lock]).where(id: session[:order_id], currency: current_currency).first
             @current_order = current_order unless current_order.try(:completed?)
@@ -59,10 +62,15 @@ module Spree
         end
 
         def remove_invalid_session_order_id
+          puts "in remove_invalid_session_order_id"
           return unless session[:order_id]
+          puts "session has an order_id: #{session[:order_id]}"
 
           order = Spree::Order.find(session[:order_id]) rescue nil
+          puts "session has an order: #{order}"
+          puts "can user edit order? #{can? :edit, order, session[:access_token]}"
           session[:order_id] = nil unless can?(:edit, order, session[:access_token])
+          puts "session[:order_id] is now #{session[:order_id]}"
         end
 
         def set_current_order

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -62,15 +62,10 @@ module Spree
         end
 
         def remove_invalid_session_order_id
-          puts "in remove_invalid_session_order_id"
           return unless session[:order_id]
-          puts "session has an order_id: #{session[:order_id]}"
 
           order = Spree::Order.find(session[:order_id]) rescue nil
-          puts "session has an order: #{order}"
-          puts "can user edit order? #{can? :edit, order, session[:access_token]}"
           session[:order_id] = nil unless can?(:edit, order, session[:access_token])
-          puts "session[:order_id] is now #{session[:order_id]}"
         end
 
         def set_current_order

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -59,16 +59,12 @@ module Spree
         end
 
         def remove_invalid_session_order_id
-          user = try_spree_current_user
+          return unless session[:order_id]
 
-          if session[:order_id]
-            order = Spree::Order.find(session[:order_id])
-            if user && order.user != user
-              session[:order_id] = nil
-            elsif !user && && order.user_id
-              session[:order_id] = nil
-            end
-          end
+          user = try_spree_current_user
+          order = Spree::Order.find(session[:order_id]) rescue nil
+
+          session[:order_id] = nil if order.nil? || order.user != user
         end
 
         def set_current_order

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,10 +2,6 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
-    def unauthorized
-      render 'spree/shared/unauthorized', :layout => Spree::Config[:layout], :status => 401
-    end
-
     protected
     
     def config_locale


### PR DESCRIPTION
Several dozen times a day, someone tries to view or add an item to their cart and receives a [CanCan authorization failure](https://app.bugsnag.com/printbear/sticker-mule/errors/57c88365089d7658b447a61e?filters[event.since][]=1d&filters[error.status][]=open) because their `spree_current_user` isn't allowed to view/edit the order in `current_order`.

I traced a few of these cases and found that in most of them either the user is logged in but the `session[:order_id]` points to a guest cart, or the user is logged out but the `session[:order_id]` points to a cart with a user attached.

I think there must be cases where your authentication status changes but `session[:order_id]` persists and just points to something you aren't allowed to see anymore.

So this PR checks the user against the order and, if they don't match, empties out the session and lets the normal logic run to determine the user's last non-complete order and save that in the session.
